### PR TITLE
Clean up script for generating URL endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,18 @@ Structure:
 }
 ```
 
-# Get queries to test locally
+# Generate URL endpoints to explore / test against
+
+Local testing:
 
 ```
-ruby test_queries.rb
+ruby test_queries.rb localhost:4567
+```
+
+Testing against Heroku app:
+
+```
+ruby test_queries.rb documents-api.herokuapp.com
 ```
 
 # Test queries locally

--- a/test_queries.rb
+++ b/test_queries.rb
@@ -1,30 +1,44 @@
 require_relative "test_fixtures"
 require          "active_support/all"
 
-puts; puts "Single employed household member:"
+@base_url = ARGV[0]
 
-puts "http://localhost:4567/api/#{SINGLE_HOUSEHOLD_MEMBER_EMPLOYED.to_query}"
+@queries = [
+  {
+    description: "Single employed household member",
+    ruby_hash: SINGLE_HOUSEHOLD_MEMBER_EMPLOYED
+  },
+  {
+    description: "Single self employed household member",
+    ruby_hash: SINGLE_HOUSEHOLD_MEMBER_SELF_EMPLOYED
+  },
+  {
+    description: "Single-member household with rental income",
+    ruby_hash: SINGLE_HOUSEHOLD_MEMBER_WITH_RENTAL_INCOME
+  },
+  {
+    description: "Multi-member household, head of household recieving child support",
+    ruby_hash: MULTI_MEMBER_HOUSEHOLD_RECEIVING_CHILD_SUPPORT
+  },
+  {
+    description: "Household applying for expedited benefits",
+    ruby_hash: EXPEDITED_BENEFITS
+  },
+  {
+    description: "Multi-member household -- retiree, disabled person, working person",
+    ruby_hash: MULTI_MEMBER_HOUSEHOLD_WITH_RETIREE_DISABLED_AND_WORKING
+  },
+  {
+    description: "Multi-member household -- unemployed person, working person",
+    ruby_hash: MULTI_MEMBER_HOUSEHOLD_WITH_UNEMPLOYED_AND_WORKING
+  }
+]
 
-puts; puts "Single self employed household member:"
+def url_endpoint(base_url, query_data)
+  "http://#{base_url}/api/#{query_data.to_query}"
+end
 
-puts "http://localhost:4567/api/#{SINGLE_HOUSEHOLD_MEMBER_SELF_EMPLOYED.to_query}"
-
-puts; puts "Single-member household with rental income:"
-
-puts "http://localhost:4567/api/#{SINGLE_HOUSEHOLD_MEMBER_WITH_RENTAL_INCOME.to_query}"
-
-puts; puts "Multi-member household, head of household recieving child support:"
-
-puts "http://localhost:4567/api/#{MULTI_MEMBER_HOUSEHOLD_RECEIVING_CHILD_SUPPORT.to_query}"
-
-puts; puts "Household applying for expedited benefits:"
-
-puts "http://localhost:4567/api/#{EXPEDITED_BENEFITS.to_query}"
-
-puts; puts "Multi-member household -- retiree, disabled person, working person:"
-
-puts "http://localhost:4567/api/#{MULTI_MEMBER_HOUSEHOLD_WITH_RETIREE_DISABLED_AND_WORKING.to_query}"
-
-puts; puts "Multi-member household -- unemployed person, working person:"
-
-puts "http://localhost:4567/api/#{MULTI_MEMBER_HOUSEHOLD_WITH_UNEMPLOYED_AND_WORKING.to_query}"
+@queries.each do |query|
+  puts; puts "#{query[:description]}:"
+  puts url_endpoint(@base_url, query[:ruby_hash])
+end


### PR DESCRIPTION
## What's new?

Allow for different `base_url` passed in as CLI argument so we can easily test queries against the API hosted on different servers (local, Heroku, etc).

For example:

 ```
ruby test_queries.rb documents-api.herokuapp.com
 ```
