### PR TITLE
Work on URL endpoint problem

### DIFF
--- a/public/javascripts/screener.js
+++ b/public/javascripts/screener.js
@@ -35,7 +35,7 @@
 
     getDefaultProps: function() {
       return {
-        source: 'https://documents-api.herokuapp.com/api/'
+        source: 'https://documents-api.herokuapp.com/api'
       };
     },
 

--- a/public/javascripts/screener.js
+++ b/public/javascripts/screener.js
@@ -54,10 +54,9 @@
     },
 
     fetchDocumentsFromServer: function () {
-      var queryString = JSON.stringify(this.state.userSubmittedData);
-
       this.serverRequest = $.get({
-        url: this.props.source + queryString,
+        url: this.props.source,
+        data: this.state.userSubmittedData,
         dataType: 'json',
         contentType: 'application/json',
         success: function (result) {


### PR DESCRIPTION
Part of #20 — client side.

Let jQuery do the work of passing in the proper params, not `JSON.stringify`. 

As suggested very intelligently here: http://stackoverflow.com/questions/26663809/error-bad-uri-when-sending-data-as-json-with-get-method-to-a-rails-resource

Based on how jQuery does params, this will require some changes on the server side as well, specifically a move from named params to query string params.