### PR TITLE
Remove DOB, fix #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,6 @@ rspec spec
         { ... DATA FOR SOCIAL SECURITY CARD DOCUMENTATION ... },
         { ... DATA FOR AWARD LETTER ... },
       ],
-      information_needed: [
-        { ... DATE OF BIRTH ... }
-      ]
     },
     {
       child_under_18: ... ,
@@ -91,7 +88,6 @@ rspec spec
       is_employed: ... ,
       receiving_child_support: ... ,
       documents_needed: [ ... ],
-      information_needed: [ ... ],
     },
     {
       child_under_18: ... ,
@@ -99,7 +95,6 @@ rspec spec
       is_employed: ... ,
       receiving_child_support: ... ,
       documents_needed: [ ... ],
-      information_needed: [ ... ],
     },
   ],
   other_documents_needed: [

--- a/models/household_member.rb
+++ b/models/household_member.rb
@@ -34,10 +34,7 @@ class HouseholdMember
   end
 
   def documents_and_info_needed
-    to_hash.merge({
-      documents_needed: documents_needed,
-      information_needed: information_needed,
-    })
+    to_hash.merge({ documents_needed: documents_needed })
   end
 
   def documents_needed
@@ -51,10 +48,6 @@ class HouseholdMember
       documents_based_on_identity,
       SOCIAL_SECURITY_CARD
     ].compact
-  end
-
-  def information_needed
-    [ DATE_OF_BIRTH ]
   end
 
   private

--- a/public/javascripts/components/document_results_display.js
+++ b/public/javascripts/components/document_results_display.js
@@ -27,25 +27,8 @@
 
       var person = this.householdMembers()[0];
       var documentsNeeded = person.documents_needed;
-      var informationNeeded = person.information_needed;
 
-      return dom.div({},
-        this.renderHouseHoldMemberDocumentsNeeded(documentsNeeded),
-        this.renderHouseholdMemberInformationNeeded(informationNeeded)
-      )
-    },
-
-    renderHouseholdMemberInformationNeeded: function (informationNeeded) {
-      if (informationNeeded.length === 0) return null;
-
-      var listOfInformationNeeded = informationNeeded.map(function (info) {
-        return dom.li({}, "Your " + info.official_name);
-      });
-
-      return dom.div({},
-        dom.p({}, 'You will need to know:'),
-        dom.ul({}, listOfInformationNeeded)
-      );
+      return this.renderHouseHoldMemberDocumentsNeeded(documentsNeeded);
     },
 
     renderHouseHoldMemberDocumentsNeeded: function (documentsNeeded) {

--- a/spec/documents_api_spec.rb
+++ b/spec/documents_api_spec.rb
@@ -23,7 +23,6 @@ describe Api::DocumentsRequest do
 
         expect(document_names.size).to eq 1
         expect(document_names).to eq ["Pay Stubs"]
-        expect(information_needed).to eq ["Social Security Number", "Date Of Birth"]
         expect(outcome[:other_documents_needed]).to eq [subject.residency_documents]
       end
 
@@ -83,14 +82,6 @@ describe Api::DocumentsRequest do
       end
     }
 
-    let(:information_needed_per_person) {
-      outcome[:household_members].map do |household_member|
-        household_member[:information_needed].map do |info|
-          info[:official_name]
-        end
-      end
-    }
-
     describe "head of household working and receiving child support" do
 
       let(:benefits_application) { MULTI_MEMBER_HOUSEHOLD_RECEIVING_CHILD_SUPPORT }
@@ -121,12 +112,6 @@ describe Api::DocumentsRequest do
           ["Pay Stubs"]
         ]
 
-        expect(information_needed_per_person).to eq [
-          ["Social Security Number", "Date Of Birth"],
-          ["Social Security Number", "Date Of Birth"],
-          ["Social Security Number", "Date Of Birth"]
-        ]
-
       end
 
     end
@@ -145,11 +130,6 @@ describe Api::DocumentsRequest do
         expect(document_names_per_person).to eq [
           ["Award Letter for Unemployment"],
           ["Pay Stubs"]
-        ]
-
-        expect(information_needed_per_person).to eq [
-          ["Social Security Number", "Date Of Birth"],
-          ["Social Security Number", "Date Of Birth"]
         ]
 
       end


### PR DESCRIPTION
+ We saw from users at the Family Community Resource Center on Fulton that including DOB wasn't helpful
+ DOB was the last item in the 'information' category, so remove that entire category