### PR TITLE
Remove Social Security card from required docs

### DIFF
--- a/models/household_member.rb
+++ b/models/household_member.rb
@@ -46,7 +46,6 @@ class HouseholdMember
       documents_based_on_retirement,
       documents_based_on_unemployment,
       documents_based_on_identity,
-      SOCIAL_SECURITY_CARD
     ].compact
   end
 


### PR DESCRIPTION
+ We saw from user research that not every applicant needed to bring in their physical Social Security card to secure benefits
+ Fix #68