### PR TITLE
Add in responsive questions for multi-member households

### DIFF
--- a/public/javascripts/components/default_data.js
+++ b/public/javascripts/components/default_data.js
@@ -1,0 +1,26 @@
+(function() {
+  window.shared || (window.shared = {});
+
+  window.shared.DefaultData = {
+    "household_members": [
+      {
+        "child_under_18": "false",
+        "disability_benefits": "false",
+        "is_employee": "false",
+        "self_employed": "false",
+        "receiving_child_support": "false",
+        "is_retired": "false",
+        "receiving_unemployment_benefits": "false",
+      }
+    ],
+    "is_applying_for_expedited": "false",
+    "has_rental_income": "false",
+    "renting": "false",
+    "owns_home": "false",
+    "shelter": "false",
+    "has_no_income": "true",
+    "living_with_family_or_friends": "false",
+    "all_citizens": "true"
+  };
+
+})();

--- a/public/javascripts/components/employment_question.js
+++ b/public/javascripts/components/employment_question.js
@@ -21,7 +21,7 @@
 
     render: function () {
       return dom.div({},
-        dom.p({}, 'Select all that apply to you:'),
+        dom.p({}, this.renderInstructions()),
         dom.input({ type: 'checkbox', onClick: this.props.onCheckEmployee }),
         dom.label({}, 'Employed'),
         dom.br({}),
@@ -43,6 +43,18 @@
           style: window.shared.ButtonStyle
         })
       );
+    },
+
+    renderInstructions: function () {
+      return 'Select all that apply to ' + this.familyOrSinglePersonString() + ':';
+    },
+
+    familyOrSinglePersonString: function () {
+      if (this.props.singlePersonHousehold) {
+        return 'you';
+      } else {
+        return 'the members of your household who receive income';
+      };
     },
 
     renderUnemploymentBenefitsQuestions: function () {

--- a/public/javascripts/components/employment_question.js
+++ b/public/javascripts/components/employment_question.js
@@ -11,6 +11,7 @@
     },
 
     propTypes: {
+      singlePersonHousehold: React.PropTypes.bool.isRequired,
       onCheckEmployee: React.PropTypes.func.isRequired,
       onCheckSelfEmployed: React.PropTypes.func.isRequired,
       onCheckRetired: React.PropTypes.func.isRequired,

--- a/public/javascripts/components/income_sources_question.js
+++ b/public/javascripts/components/income_sources_question.js
@@ -5,6 +5,7 @@
   window.shared.IncomeSourcesQuestion = React.createClass({
 
     propTypes: {
+      singlePersonHousehold: React.PropTypes.bool.isRequired,
       onCheckDisabilityBenefits: React.PropTypes.func.isRequired,
       onCheckChildSupport: React.PropTypes.func.isRequired,
       onCheckRentalIncome: React.PropTypes.func.isRequired,

--- a/public/javascripts/components/income_sources_question.js
+++ b/public/javascripts/components/income_sources_question.js
@@ -14,7 +14,7 @@
 
     render: function () {
       return dom.div({},
-        dom.p({}, 'Which of the following do you receive:'),
+        dom.p({}, this.question()),
         dom.input({ type: 'checkbox', onClick: this.props.onCheckDisabilityBenefits }),
         dom.label({}, 'Disability benefits'),
         dom.br({}),
@@ -35,6 +35,18 @@
           style: window.shared.ButtonStyle
         })
       );
+    },
+
+    question: function () {
+      return 'Which of the following do ' + this.familyOrSinglePersonString() + ' receive:'
+    },
+
+    familyOrSinglePersonString: function () {
+      if (this.props.singlePersonHousehold) {
+        return 'you';
+      } else {
+        return 'your household';
+      };
     },
 
   });

--- a/public/javascripts/components/initial_income_question.js
+++ b/public/javascripts/components/initial_income_question.js
@@ -5,14 +5,14 @@
   window.shared.InitialIncomeQuestion = React.createClass({
 
     propTypes: {
+      singlePersonHousehold: React.PropTypes.bool.isRequired,
       onClickYesIncome: React.PropTypes.func.isRequired,
       onClickNoIncome: React.PropTypes.func.isRequired
     },
 
     render: function () {
       return dom.div({},
-        dom.h1({}, 'See what documents you need for Food Stamps'),
-        dom.p({}, 'Are you currently receiving any income through employment, public aid, or some other means?'),
+        dom.p({}, this.question()),
         dom.input({ type: 'radio', onClick: this.props.onClickYesIncome }),
         dom.label({}, 'Yes'),
         dom.br({}),
@@ -20,6 +20,19 @@
         dom.label({}, 'No')
       );
     },
+
+    question: function () {
+      return ('Are you ' + this.familyParenthetical() + ' currently receiving ' +
+              'any income through employment, public aid, or some other means?');
+    },
+
+    familyParenthetical: function () {
+      if (this.props.singlePersonHousehold) {
+        return '';
+      } else {
+        return '(or anyone in your family)';
+      };
+    }
 
   });
 })();

--- a/public/javascripts/components/number_of_people_question.js
+++ b/public/javascripts/components/number_of_people_question.js
@@ -1,0 +1,21 @@
+(function() {
+  window.shared || (window.shared = {});
+  var dom = React.DOM;
+
+  window.shared.NumberOfPeopleQuestion = React.createClass({
+
+    render: function () {
+      return dom.div({},
+        dom.h1({}, 'See what documents you need for Food Stamps'),
+        dom.p({}, 'How many people are you applying for?'),
+        dom.input({ type: 'radio', name: 'NumberOfPeopleQuestion' }),
+        dom.label({}, '  Just Me'),
+        dom.br({}),
+        dom.input({ type: 'radio', name: 'NumberOfPeopleQuestion' }),
+        dom.label({}, '  My Family')
+      );
+    },
+
+  });
+
+})();

--- a/public/javascripts/components/number_of_people_question.js
+++ b/public/javascripts/components/number_of_people_question.js
@@ -4,14 +4,27 @@
 
   window.shared.NumberOfPeopleQuestion = React.createClass({
 
+    propTypes: {
+      onClickJustMe: React.PropTypes.func.isRequired,
+      onClickMyFamily: React.PropTypes.func.isRequired
+    },
+
     render: function () {
       return dom.div({},
         dom.h1({}, 'See what documents you need for Food Stamps'),
         dom.p({}, 'How many people are you applying for?'),
-        dom.input({ type: 'radio', name: 'NumberOfPeopleQuestion' }),
+        dom.input({
+          type: 'radio',
+          name: 'NumberOfPeopleQuestion',
+          onClick: this.props.onClickJustMe
+        }),
         dom.label({}, '  Just Me'),
         dom.br({}),
-        dom.input({ type: 'radio', name: 'NumberOfPeopleQuestion' }),
+        dom.input({
+          type: 'radio',
+          name: 'NumberOfPeopleQuestion',
+          onClick: this.props.onClickMyFamily
+        }),
         dom.label({}, '  My Family')
       );
     },

--- a/public/javascripts/screener.js
+++ b/public/javascripts/screener.js
@@ -126,6 +126,7 @@
 
     renderInitialIncomeQuestion: function () {
       return createEl(InitialIncomeQuestion, {
+        singlePersonHousehold: this.state.singlePersonHousehold,
         onClickNoIncome: this.onClickNoIncome,
         onClickYesIncome: this.onClickYesIncome
       });
@@ -133,6 +134,7 @@
 
     renderEmploymentQuestion: function () {
       return createEl(EmploymentQuestion, {
+        singlePersonHousehold: this.state.singlePersonHousehold,
         onCheckEmployee: this.onCheckEmployee,
         onCheckSelfEmployed: this.onCheckSelfEmployed,
         onCheckRetired: this.onCheckRetired,
@@ -143,6 +145,7 @@
 
     renderIncomeSourcesQuestion: function () {
       return createEl(IncomeSourcesQuestion, {
+        singlePersonHousehold: this.state.singlePersonHousehold,
         onCheckDisabilityBenefits: this.onCheckDisabilityBenefits,
         onCheckChildSupport: this.onCheckChildSupport,
         onCheckRentalIncome: this.onCheckRentalIncome,

--- a/public/javascripts/screener.js
+++ b/public/javascripts/screener.js
@@ -25,7 +25,8 @@
         answeredIncomeSourcesQuestion: false,
         hasResponseFromServer: false,
         documentsDataFromServer: null,
-        userSubmittedData: DefaultData
+        userSubmittedData: DefaultData,
+        singlePersonHousehold: true
       };
     },
 
@@ -98,7 +99,10 @@
     },
 
     renderNumberOfPeople: function () {
-      return createEl(NumberOfPeopleQuestion, {});
+      return createEl(NumberOfPeopleQuestion, {
+        onClickJustMe: this.onClickJustMe,
+        onClickMyFamily: this.onClickMyFamily
+      });
     },
 
     renderCitizenshipQuestion: function () {
@@ -168,6 +172,17 @@
       };
 
       this.setState({ userSubmittedData: userSubmittedData });
+    },
+
+    onClickJustMe: function () {
+      this.setState({ answeredNumberOfPeople: true });
+    },
+
+    onClickMyFamily: function () {
+      this.setState({
+        answeredNumberOfPeople: true,
+        singlePersonHousehold: false,
+      });
     },
 
     onUpdateLivingSituation: function (attribute_name) {

--- a/public/javascripts/screener.js
+++ b/public/javascripts/screener.js
@@ -6,6 +6,7 @@
   var DefaultData = window.shared.DefaultData;
 
   var DocumentResultsDisplay = window.shared.DocumentResultsDisplay;
+  var NumberOfPeopleQuestion = window.shared.NumberOfPeopleQuestion;
   var InitialIncomeQuestion = window.shared.InitialIncomeQuestion;
   var EmploymentQuestion = window.shared.EmploymentQuestion;
   var IncomeSourcesQuestion = window.shared.IncomeSourcesQuestion;
@@ -16,6 +17,7 @@
 
     getInitialState: function() {
       return {
+        answeredNumberOfPeople: false,
         answeredInitialIncomeQuestion: false,
         answeredHousingQuestion: false,
         answeredCitizenshipQuestion: false,
@@ -74,7 +76,9 @@
         // Otherwise, serve the appropriate question in the screener:
         resultsFromServer = null;
 
-        if (this.state.answeredInitialIncomeQuestion === false) {
+        if (this.state.answeredNumberOfPeople === false) {
+          currentQuestion = this.renderNumberOfPeople();
+        } else if (this.state.answeredInitialIncomeQuestion === false) {
           currentQuestion = this.renderInitialIncomeQuestion();
         } else if (this.state.answeredHousingQuestion == false) {
           currentQuestion = this.renderHousingQuestion();
@@ -91,6 +95,10 @@
         currentQuestion,
         resultsFromServer
       )
+    },
+
+    renderNumberOfPeople: function () {
+      return createEl(NumberOfPeopleQuestion, {});
     },
 
     renderCitizenshipQuestion: function () {

--- a/public/javascripts/screener.js
+++ b/public/javascripts/screener.js
@@ -2,6 +2,9 @@
   window.shared || (window.shared = {});
   var dom = React.DOM;
   var createEl = React.createElement.bind(React);
+
+  var DefaultData = window.shared.DefaultData;
+
   var DocumentResultsDisplay = window.shared.DocumentResultsDisplay;
   var InitialIncomeQuestion = window.shared.InitialIncomeQuestion;
   var EmploymentQuestion = window.shared.EmploymentQuestion;
@@ -12,9 +15,6 @@
   var DocumentScreener = React.createClass({
 
     getInitialState: function() {
-      // Any changes made to this data structure should also be reflected
-      // in `onClickStartOver` at the bottom of this file.
-
       return {
         answeredInitialIncomeQuestion: false,
         answeredHousingQuestion: false,
@@ -23,28 +23,7 @@
         answeredIncomeSourcesQuestion: false,
         hasResponseFromServer: false,
         documentsDataFromServer: null,
-        userSubmittedData: {
-          // Defaults:
-          "household_members": [
-            {
-              "child_under_18": "false",
-              "disability_benefits": "false",
-              "is_employee": "false",
-              "self_employed": "false",
-              "receiving_child_support": "false",
-              "is_retired": "false",
-              "receiving_unemployment_benefits": "false",
-            }
-          ],
-          "is_applying_for_expedited": "false",
-          "has_rental_income": "false",
-          "renting": "false",
-          "owns_home": "false",
-          "shelter": "false",
-          "has_no_income": "true",
-          "living_with_family_or_friends": "false",
-          "all_citizens": "true"
-        }
+        userSubmittedData: DefaultData
       };
     },
 
@@ -291,28 +270,7 @@
         answeredIncomeSourcesQuestion: false,
         hasResponseFromServer: false,
         documentsDataFromServer: null,
-        userSubmittedData: {
-          // Defaults:
-          "household_members": [
-            {
-              "child_under_18": "false",
-              "disability_benefits": "false",
-              "is_employee": "false",
-              "self_employed": "false",
-              "receiving_child_support": "false",
-              "is_retired": "false",
-              "receiving_unemployment_benefits": "false",
-            }
-          ],
-          "is_applying_for_expedited": "false",
-          "has_rental_income": "false",
-          "renting": "false",
-          "owns_home": "false",
-          "shelter": "false",
-          "has_no_income": "true",
-          "living_with_family_or_friends": "false",
-          "all_citizens": "true"
-        }
+        userSubmittedData: DefaultData
       });
     },
 

--- a/views/show.erb
+++ b/views/show.erb
@@ -34,6 +34,7 @@
 <script src="javascripts/components/residency_documents.js"></script>
 <script src="javascripts/components/identity_documents.js"></script>
 
+<script src="javascripts/components/default_data.js"></script>
 <script src="javascripts/components/document_results_display.js"></script>
 
 <script src="javascripts/components/citizenship_question.js"></script>

--- a/views/show.erb
+++ b/views/show.erb
@@ -37,6 +37,7 @@
 <script src="javascripts/components/default_data.js"></script>
 <script src="javascripts/components/document_results_display.js"></script>
 
+<script src="javascripts/components/number_of_people_question.js"></script>
 <script src="javascripts/components/citizenship_question.js"></script>
 <script src="javascripts/components/housing_question.js"></script>
 <script src="javascripts/components/initial_income_question.js"></script>


### PR DESCRIPTION
# Notes

+ This is just a first step: adding in an initial question about household size and making the subsequent questions responsive
+ The final documents display step is not responsive to household size yet
+ We are going with a "flattening" approach here, not asking about which specific household members are receiving which types of income 

# GIF

![number-of-people-question](https://cloud.githubusercontent.com/assets/3209501/17300600/ab0e3882-57d8-11e6-8a4c-58c8773d9794.gif)
