### PR TITLE
Remove is_applying_for_expedited option from data structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ rspec spec
       receiving_child_support: ... ,
     },
   ],
-  is_applying_for_expedited: ...,     # Is this an application for expedited benefits?
   has_rental_income: ...,             # Does the household have any rental income?
   renting: ...,                       # Is the household renting?
   owns_home: ...,                     # Is this a homeowning household?

--- a/app.rb
+++ b/app.rb
@@ -18,7 +18,6 @@ get '/api' do
 
   documents_request = Api::DocumentsRequest.new(
     household_members: params["household_members"],
-    is_applying_for_expedited: params["is_applying_for_expedited"],
     has_rental_income: params["has_rental_income"],
     renting: params["renting"],
     owns_home: params["owns_home"],

--- a/documents_api.rb
+++ b/documents_api.rb
@@ -7,7 +7,6 @@ module Api
   class DocumentsRequest
 
     def initialize(household_members:,
-                   is_applying_for_expedited:,
                    has_rental_income:,
                    renting:,
                    owns_home:,
@@ -17,7 +16,6 @@ module Api
     )
 
       @household_members = reformat_household_members(household_members)
-      @is_applying_for_expedited = StringParser.new(is_applying_for_expedited).to_boolean
       @has_rental_income = StringParser.new(has_rental_income).to_boolean
       @renting = StringParser.new(renting).to_boolean
       @owns_home = StringParser.new(owns_home).to_boolean
@@ -25,7 +23,7 @@ module Api
       @living_with_family_or_friends = StringParser.new(living_with_family_or_friends).to_boolean
       @all_citizens = StringParser.new(all_citizens).to_boolean
 
-      raise "Badly formatted request" if @is_applying_for_expedited.nil? || @has_rental_income.nil?
+      raise "Badly formatted request" if @has_rental_income.nil?
     end
 
     def fetch_documents
@@ -49,7 +47,7 @@ module Api
     def other_documents_needed
       other_documents = [residency_documents.list]
 
-      other_documents << BANK_STATEMENTS if (@is_applying_for_expedited || @has_rental_income)
+      other_documents << BANK_STATEMENTS if @has_rental_income
 
       other_documents << I_90_DOCUMENTATION unless @all_citizens
 

--- a/public/javascripts/components/default_data.js
+++ b/public/javascripts/components/default_data.js
@@ -13,7 +13,6 @@
         "receiving_unemployment_benefits": "false",
       }
     ],
-    "is_applying_for_expedited": "false",
     "has_rental_income": "false",
     "renting": "false",
     "owns_home": "false",

--- a/spec/documents_api_spec.rb
+++ b/spec/documents_api_spec.rb
@@ -6,7 +6,6 @@ describe Api::DocumentsRequest do
   subject {
     described_class.new(
       household_members: incoming_params[:household_members],
-      is_applying_for_expedited: incoming_params[:is_applying_for_expedited],
       has_rental_income: incoming_params[:has_rental_income]
     )
   }


### PR DESCRIPTION
# Note

+ We don't currently have the feature for users to specify expedited benefits ...
+ ... so we can take out this option to reduce complexity and make refactoring a bit simpler