### PR TITLE
Fix SMS flow

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -7,7 +7,7 @@ require './local_env' if File.exists?('local_env.rb')
 
 require_relative 'api/documents_api'
 require_relative 'sms/incoming_message_handler'
-require_relative 'helpers/session_updater'
+require_relative 'sms/session_data_updater'
 
 configure do
   enable :cross_origin
@@ -69,14 +69,16 @@ post '/sms' do
   session['child_support'] ||= 'false'
   session['has_state_id'] ||= 'true'
 
-  # Use the object to increment the session data with user's answers
+  # Update the session data with user's answers
+  updated_session = SessionDataUpdater.new(session, params[:Body]).update_data
+  session = updated_session
 
   # Send a response
-  response = handler.respond
+  # response = handler.respond
 
   # Increment the session step
 
   # Return the response for testing purposes
-  return response
+  return nil
 end
 

--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,7 @@ require './local_env' if File.exists?('local_env.rb')
 
 require_relative 'api/documents_api'
 require_relative 'sms/incoming_message_handler'
+require_relative 'helpers/session_updater'
 
 configure do
   enable :cross_origin
@@ -51,7 +52,7 @@ get '/' do
 end
 
 post '/sms' do
-  # Set up defaults
+  # Set up defaults in case the user is starting from scratch
   session['step'] ||= 'initial'
   session['single_person_household'] ||= 'true'
   session['renting'] ||= 'false'
@@ -68,9 +69,14 @@ post '/sms' do
   session['child_support'] ||= 'false'
   session['has_state_id'] ||= 'true'
 
-  handler = IncomingMessageHandler.new(params[:From], params[:Body], session)
+  # Use the object to increment the session data with user's answers
+
+  # Send a response
   response = handler.respond
-  session = handler.updated_session
+
+  # Increment the session step
+
+  # Return the response for testing purposes
   return response
 end
 

--- a/app.rb
+++ b/app.rb
@@ -54,7 +54,7 @@ end
 
 post '/sms' do
   # Set up defaults in case the user is starting from scratch
-  session['step'] ||= 'initial'
+  session['count'] ||= 0
   session['single_person_household'] ||= 'true'
   session['renting'] ||= 'false'
   session['owns_home'] ||= 'false'
@@ -70,7 +70,7 @@ post '/sms' do
   session['child_support'] ||= 'false'
   session['has_state_id'] ||= 'true'
 
-  # Update the session data with user's answers
+  # Update the session data
   new_session = SessionDataUpdater.new(session, params[:Body]).update_data
   session = new_session
 

--- a/app.rb
+++ b/app.rb
@@ -8,6 +8,7 @@ require './local_env' if File.exists?('local_env.rb')
 require_relative 'api/documents_api'
 require_relative 'sms/incoming_message_handler'
 require_relative 'sms/session_data_updater'
+require_relative 'sms/session_step_incrementer'
 
 configure do
   enable :cross_origin
@@ -70,13 +71,16 @@ post '/sms' do
   session['has_state_id'] ||= 'true'
 
   # Update the session data with user's answers
-  updated_session = SessionDataUpdater.new(session, params[:Body]).update_data
-  session = updated_session
+  new_session = SessionDataUpdater.new(session, params[:Body]).update_data
+  session = new_session
 
   # Send a response
+  # handler =
   # response = handler.respond
 
   # Increment the session step
+  new_session = SessionStepIncrementer.new(session).increment
+  session = new_session
 
   # Return the response for testing purposes
   return nil

--- a/app.rb
+++ b/app.rb
@@ -6,7 +6,7 @@ require          'twilio-ruby'
 require './local_env' if File.exists?('local_env.rb')
 
 require_relative 'api/documents_api'
-require_relative 'sms/incoming_message_handler'
+require_relative 'sms/responder'
 require_relative 'sms/session_data_updater'
 require_relative 'sms/session_step_incrementer'
 
@@ -75,14 +75,13 @@ post '/sms' do
   session = new_session
 
   # Send a response
-  # handler =
-  # response = handler.respond
+  response = Responder.new(params[:From], session).respond
 
   # Increment the session step
   new_session = SessionStepIncrementer.new(session).increment
   session = new_session
 
   # Return the response for testing purposes
-  return nil
+  return response
 end
 

--- a/sms/incoming_message_handler.rb
+++ b/sms/incoming_message_handler.rb
@@ -13,24 +13,6 @@ class IncomingMessageHandler < Struct.new :from, :original_body, :session
     return message
   end
 
-  def updated_session
-    SessionUpdater.new(session, body, next_step, previous_step).update
-  end
-
-  def next_step
-    screener_steps[current_step_index + 1]
-  end
-
-  def previous_step
-    screener_steps[current_step_index - 1]
-  end
-
-  private
-
-  def step
-    session['step']
-  end
-
   def send_results?
     step == 'result'
   end
@@ -41,22 +23,6 @@ class IncomingMessageHandler < Struct.new :from, :original_body, :session
     else
       SMS_SCREENER[step]
     end
-  end
-
-  def screener_steps
-    [
-      'initial',
-      'housing_question',
-      'citizenship_question',
-      'employment_question',
-      'other_income_sources_question',
-      'state_id_question',
-      'result',
-    ]
-  end
-
-  def current_step_index
-    screener_steps.index(step)
   end
 
   def client

--- a/sms/incoming_message_handler.rb
+++ b/sms/incoming_message_handler.rb
@@ -1,6 +1,5 @@
 require_relative 'document_results_message'
 require_relative 'sms_screener_questions'
-require_relative '../helpers/session_updater'
 
 class IncomingMessageHandler < Struct.new :from, :original_body, :session
 
@@ -34,10 +33,6 @@ class IncomingMessageHandler < Struct.new :from, :original_body, :session
 
   def send_results?
     step == 'result'
-  end
-
-  def body
-    original_body.upcase
   end
 
   def message

--- a/sms/responder.rb
+++ b/sms/responder.rb
@@ -1,7 +1,7 @@
 require_relative 'document_results_message'
 require_relative 'sms_screener_questions'
 
-class IncomingMessageHandler < Struct.new :from, :original_body, :session
+class Responder < Struct.new :from, :session
 
   def respond
     client.messages.create(
@@ -13,8 +13,14 @@ class IncomingMessageHandler < Struct.new :from, :original_body, :session
     return message
   end
 
+  private
+
   def send_results?
     step == 'result'
+  end
+
+  def step
+    session['step']
   end
 
   def message

--- a/sms/responder.rb
+++ b/sms/responder.rb
@@ -16,11 +16,11 @@ class Responder < Struct.new :from, :session
   private
 
   def send_results?
-    step == 'result'
+    session[:count] == 6
   end
 
   def step
-    session['step']
+    session[:count]
   end
 
   def message

--- a/sms/session_data_updater.rb
+++ b/sms/session_data_updater.rb
@@ -3,26 +3,28 @@ class SessionDataUpdater < Struct.new :session, :original_body
   def update_data
     new_session = session.clone
 
-    case new_session[:step]
-    when 'initial'
+    return new_session if new_session[:count] == 0
+
+    case new_session[:count]
+    when 1
       new_session['single_person_household'] = 'false' if body == 'B'
-    when 'housing_question'
+    when 2
       new_session['renting'] = 'true' if body == 'A'
       new_session['owns_home'] = 'true' if body == 'B'
       new_session['living_with_family_or_friends'] = 'true' if body == 'C'
       new_session['shelter'] = 'true' if body == 'D'
-    when 'citizenship_question'
+    when 3
       new_session['all_citizens'] = 'false' if body == 'NO'
-    when 'employment_question'
+    when 4
       new_session['employee'] = 'true' if body == 'A'
       new_session['self_employed'] = 'true' if body == 'B'
       new_session['retired'] = 'true' if body == 'C'
       new_session['unemployment_benefits'] = 'true' if body == 'D'
-    when 'other_income_sources_question'
+    when 5
       new_session['disability_benefits'] = 'true' if body == 'A'
       new_session['child_support'] = 'true' if body == 'B'
       new_session['has_rental_income'] = 'true' if body == 'C'
-    when 'state_id_question'
+    when 6
       new_session['has_state_id'] = 'false' if body == 'NO'
     end
 

--- a/sms/session_data_updater.rb
+++ b/sms/session_data_updater.rb
@@ -1,9 +1,9 @@
-class SessionUpdater < Struct.new :session, :body, :next_step, :previous_step
+class SessionDataUpdater < Struct.new :session, :original_body
 
-  def update
+  def update_data
     new_session = session.clone
 
-    case previous_step
+    case new_session[:step]
     when 'initial'
       new_session['single_person_household'] = 'false' if body == 'B'
     when 'housing_question'
@@ -26,9 +26,11 @@ class SessionUpdater < Struct.new :session, :body, :next_step, :previous_step
       new_session['has_state_id'] = 'false' if body == 'NO'
     end
 
-    new_session['step'] = next_step
-
     return new_session
+  end
+
+  def body
+    original_body.upcase
   end
 
 end

--- a/sms/session_step_incrementer.rb
+++ b/sms/session_step_incrementer.rb
@@ -3,33 +3,9 @@ class SessionStepIncrementer < Struct.new :session
   def increment
     new_session = session.clone
 
-    new_session['step'] = next_step
+    new_session[:count] += 1
 
     return new_session
-  end
-
-  def step
-    session['step']
-  end
-
-  def next_step
-    screener_steps[current_step_index + 1]
-  end
-
-  def screener_steps
-    [
-      'initial',
-      'housing_question',
-      'citizenship_question',
-      'employment_question',
-      'other_income_sources_question',
-      'state_id_question',
-      'result',
-    ]
-  end
-
-  def current_step_index
-    screener_steps.index(step)
   end
 
 end

--- a/sms/session_step_incrementer.rb
+++ b/sms/session_step_incrementer.rb
@@ -1,0 +1,35 @@
+class SessionStepIncrementer < Struct.new :session
+
+  def increment
+    new_session = session.clone
+
+    new_session['step'] = next_step
+
+    return new_session
+  end
+
+  def step
+    session['step']
+  end
+
+  def next_step
+    screener_steps[current_step_index + 1]
+  end
+
+  def screener_steps
+    [
+      'initial',
+      'housing_question',
+      'citizenship_question',
+      'employment_question',
+      'other_income_sources_question',
+      'state_id_question',
+      'result',
+    ]
+  end
+
+  def current_step_index
+    screener_steps.index(step)
+  end
+
+end

--- a/sms/sms_screener_questions.rb
+++ b/sms/sms_screener_questions.rb
@@ -1,11 +1,11 @@
 SMS_SCREENER = {
-  'initial' => (
+  0 => (
     'Welcome. ' +
     'Here you can find out what documents you need to apply for Food Stamps. ' +
     'How many people are you applying for? ' +
     'A. Just Me. B. My Family.'
   ),
-  'housing_question' => (
+  1 => (
     'Describe your living situation: ' +
     'A. Renting. ' +
     'B. Own home. ' +
@@ -13,11 +13,11 @@ SMS_SCREENER = {
     'D. Shelter. ' +
     'E. None of the above. '
   ),
-  'citizenship_question' => (
+  2 => (
     'Is everyone in your household a US citizen? ' +
     'Yes or No.'
   ),
-  'employment_question' => (
+  3 => (
     'Select all that describe you: ' +
     'A. Employed. ' +
     'B. Self-employed. ' +
@@ -25,14 +25,14 @@ SMS_SCREENER = {
     'D. Receiving unemployment benefits. ' +
     'E. None of the above.'
   ),
-  'other_income_sources_question' => (
+  4 => (
     'Which of the following do you receive: ' +
     'A. Disability benefits. ' +
     'B. Child support. ' +
     'C. Rental income. ' +
     'D. None of the above.'
   ),
-  'state_id_question' => (
+  5 => (
     'Do you have a State ID? Yes or No.'
   )
 }

--- a/spec/sms/sms_integration_spec.rb
+++ b/spec/sms/sms_integration_spec.rb
@@ -22,17 +22,11 @@ describe 'SMS conversation' do
 
     it 'responds with the correct documents' do
       send_sms('Hi!')
-      expect(last_response.body).to eq SMS_SCREENER['initial']
       send_sms('A')    # Just Me
-      expect(last_response.body).to eq SMS_SCREENER['housing_question']
       send_sms('A')    # Renting
-      expect(last_response.body).to eq SMS_SCREENER['citizenship_question']
       send_sms('YES')  # All citizens
-      expect(last_response.body).to eq SMS_SCREENER['employment_question']
       send_sms('B')    # Self-employed
-      expect(last_response.body).to eq SMS_SCREENER['other_income_sources_question']
       send_sms('D')    # None of the above
-      expect(last_response.body).to eq SMS_SCREENER['state_id_question']
       send_sms('YES')  # Has State ID
       expect(last_response.body).to eq expected_documents
     end

--- a/spec/sms/sms_integration_spec.rb
+++ b/spec/sms/sms_integration_spec.rb
@@ -15,92 +15,100 @@ describe 'SMS conversation' do
     }
   end
 
-  describe '1 person, renting, citizen, self-employed, no other income, has state ID' do
-    let(:expected_documents) {
-      'You will need these documents: State ID, Self-Employment Form.'
-    }
+  describe 'has State ID' do
 
-    it 'responds with the correct documents' do
-      send_sms('Hi!')
-      send_sms('A')    # Just Me
-      send_sms('A')    # Renting
-      send_sms('YES')  # All citizens
-      send_sms('B')    # Self-employed
-      send_sms('D')    # None of the above
-      send_sms('YES')  # Has State ID
-      expect(last_response.body).to eq expected_documents
+    describe '1 person, renting, citizen, self-employed, no other income, has state ID' do
+      let(:expected_documents) {
+        'You will need these documents: State ID, Self-Employment Form.'
+      }
+
+      it 'responds with the correct documents' do
+        send_sms('Hi!')
+        send_sms('A')    # Just Me
+        send_sms('A')    # Renting
+        send_sms('YES')  # All citizens
+        send_sms('B')    # Self-employed
+        send_sms('D')    # None of the above
+        send_sms('YES')  # Has State ID
+        expect(last_response.body).to eq expected_documents
+      end
     end
+
+    describe '1 person, renting, citizen, employee, no other income, has state ID' do
+      let(:expected_documents) {
+        'You will need these documents: State ID, Pay Stubs.'
+      }
+
+      it 'responds with the correct documents' do
+        send_sms('Hi!')
+        send_sms('A')    # Just Me
+        send_sms('A')    # Renting
+        send_sms('YES')  # All citizens
+        send_sms('A')    # Employee
+        send_sms('D')    # None of the above
+        send_sms('YES')  # Has State ID
+        expect(last_response.body).to eq expected_documents
+      end
+    end
+
+    describe '1 person, owns home, citizen, employee, child support, has state ID' do
+      let(:expected_documents) {
+        'You will need these documents: ' +
+        'State ID, Pay Stubs, Written Child Support Statement.'
+      }
+
+      it 'responds with the correct documents' do
+        send_sms('Hi!')
+        send_sms('A')    # Just Me
+        send_sms('B')    # Owns home
+        send_sms('YES')  # All citizens
+        send_sms('A')    # Employee
+        send_sms('B')    # Child support
+        send_sms('YES')  # Has State ID
+        expect(last_response.body).to eq expected_documents
+      end
+    end
+
   end
 
-  describe 'family, renting, citizens, self-employed, no other income, has state ID' do
-    let(:expected_documents) {
-      'You will need these documents: ' +
-      'State IDs for everyone you are applying for, Self-Employment Form.'
-    }
+  describe 'no state ID' do
 
-    it 'responds with the correct documents' do
-      send_sms('Hi!')
-      send_sms('B')    # My Family
-      send_sms('A')    # Renting
-      send_sms('YES')  # All citizens
-      send_sms('B')    # Self-employed
-      send_sms('D')    # None of the above
-      send_sms('NO')   # No State ID
-      expect(last_response.body).to eq expected_documents
+    describe '1 person, renting, not citizen, self-employed, no other income, no state ID' do
+      let(:expected_documents) {
+        'You will need these documents: ' +
+        'State ID, I-90 Documentation for all non-citizen family members, Self-Employment Form.'
+      }
+
+      it 'responds with the correct documents' do
+        send_sms('Hi!')
+        send_sms('A')    # 1 Person
+        send_sms('A')    # Renting
+        send_sms('NO')   # Not citizen
+        send_sms('B')    # Self-employed
+        send_sms('D')    # None of the above
+        send_sms('NO')   # No State ID
+        expect(last_response.body).to eq expected_documents
+      end
     end
-  end
 
-  describe '1 person, renting, not citizen, self-employed, no other income, has state ID' do
-    let(:expected_documents) {
-      'You will need these documents: ' +
-      'State ID, I-90 Documentation for all non-citizen family members, Self-Employment Form.'
-    }
+    describe 'family, renting, citizens, self-employed, no other income, has state ID' do
+      let(:expected_documents) {
+        'You will need these documents: ' +
+        'State IDs for everyone you are applying for, Self-Employment Form.'
+      }
 
-    it 'responds with the correct documents' do
-      send_sms('Hi!')
-      send_sms('A')    # 1 Person
-      send_sms('A')    # Renting
-      send_sms('NO')   # Not citizen
-      send_sms('B')    # Self-employed
-      send_sms('D')    # None of the above
-      send_sms('NO')   # No State ID
-      expect(last_response.body).to eq expected_documents
+      it 'responds with the correct documents' do
+        send_sms('Hi!')
+        send_sms('B')    # My Family
+        send_sms('A')    # Renting
+        send_sms('YES')  # All citizens
+        send_sms('B')    # Self-employed
+        send_sms('D')    # None of the above
+        send_sms('NO')   # No State ID
+        expect(last_response.body).to eq expected_documents
+      end
     end
-  end
 
-  describe '1 person, renting, citizen, employee, no other income, has state ID' do
-    let(:expected_documents) {
-      'You will need these documents: State ID, Pay Stubs.'
-    }
-
-    it 'responds with the correct documents' do
-      send_sms('Hi!')
-      send_sms('A')    # Just Me
-      send_sms('A')    # Renting
-      send_sms('YES')  # All citizens
-      send_sms('A')    # Employee
-      send_sms('D')    # None of the above
-      send_sms('YES')  # Has State ID
-      expect(last_response.body).to eq expected_documents
-    end
-  end
-
-  describe '1 person, owns home, citizen, employee, child support, has state ID' do
-    let(:expected_documents) {
-      'You will need these documents: ' +
-      'State ID, Pay Stubs, Written Child Support Statement.'
-    }
-
-    it 'responds with the correct documents' do
-      send_sms('Hi!')
-      send_sms('A')    # Just Me
-      send_sms('B')    # Owns home
-      send_sms('YES')  # All citizens
-      send_sms('A')    # Employee
-      send_sms('B')    # Child support
-      send_sms('YES')  # Has State ID
-      expect(last_response.body).to eq expected_documents
-    end
   end
 
 end

--- a/spec/sms/sms_integration_spec.rb
+++ b/spec/sms/sms_integration_spec.rb
@@ -17,19 +17,20 @@ describe 'SMS conversation' do
 
   describe 'has State ID' do
 
-    describe '1 person, renting, citizen, self-employed, no other income, has state ID' do
+    describe 'family, renting, citizens, self-employed, no other income, has state ID' do
       let(:expected_documents) {
-        'You will need these documents: State ID, Self-Employment Form.'
+        'You will need these documents: ' +
+        'State IDs for everyone you are applying for, Self-Employment Form.'
       }
 
       it 'responds with the correct documents' do
         send_sms('Hi!')
-        send_sms('A')    # Just Me
+        send_sms('B')    # My Family
         send_sms('A')    # Renting
         send_sms('YES')  # All citizens
         send_sms('B')    # Self-employed
         send_sms('D')    # None of the above
-        send_sms('YES')  # Has State ID
+        send_sms('YES')   # No State ID
         expect(last_response.body).to eq expected_documents
       end
     end
@@ -75,8 +76,11 @@ describe 'SMS conversation' do
 
     describe '1 person, renting, not citizen, self-employed, no other income, no state ID' do
       let(:expected_documents) {
-        'You will need these documents: ' +
-        'State ID, I-90 Documentation for all non-citizen family members, Self-Employment Form.'
+        'Since you don\'t have a State ID, you will need to prove residency. ' +
+        'You will need *ONE* of the following to prove residency: ' +
+        'Rent Receipt, Mail, Medical Records. ' +
+        'You will also need these documents: ' +
+        'I-90 Documentation for all non-citizen family members, Self-Employment Form.'
       }
 
       it 'responds with the correct documents' do
@@ -91,20 +95,22 @@ describe 'SMS conversation' do
       end
     end
 
-    describe 'family, renting, citizens, self-employed, no other income, has state ID' do
+    describe '1 person, renting, citizen, self-employed, no other income, no state ID' do
       let(:expected_documents) {
-        'You will need these documents: ' +
-        'State IDs for everyone you are applying for, Self-Employment Form.'
+        'Since you don\'t have a State ID, you will need to prove residency. ' +
+        'You will need *ONE* of the following to prove residency: ' +
+        'Rent Receipt, Mail, Medical Records. ' +
+        'You will also need a Self-Employment Form.'
       }
 
       it 'responds with the correct documents' do
         send_sms('Hi!')
-        send_sms('B')    # My Family
+        send_sms('A')    # Just Me
         send_sms('A')    # Renting
         send_sms('YES')  # All citizens
         send_sms('B')    # Self-employed
         send_sms('D')    # None of the above
-        send_sms('NO')   # No State ID
+        send_sms('NO')  # No State ID
         expect(last_response.body).to eq expected_documents
       end
     end


### PR DESCRIPTION
# Notes

+ Use counts instead of strings to keep track of strings: thanks for the pairing @genevievenielsen!
+ Also break up SMS response into more objects with single responsibilities
+ Add specs for has state ID / does not have state ID cases 