### PR TITLE
Make 'no state ID' buttons regular size; italicized

### DIFF
--- a/public/javascripts/styles/link_style.js
+++ b/public/javascripts/styles/link_style.js
@@ -6,7 +6,7 @@
     textDecoration: 'underline',
     lineHeight: '40px',
     cursor: 'pointer',
-    fontSize: '13px'
+    fontStyle: 'italic'
   };
 
 })();


### PR DESCRIPTION
# Notes

+ Based on user testing at Harold Washington Library; one of our elderly testers didn't notice these buttons
+ Fix #137