### PR TITLE
Improve housing question flow with BACK button

### DIFF
--- a/public/javascripts/components/first_page.js
+++ b/public/javascripts/components/first_page.js
@@ -12,9 +12,9 @@
       onClickNext: React.PropTypes.func.isRequired,
       onClickMyFamily: React.PropTypes.func.isRequired,
       onUpdateLivingSituationField: React.PropTypes.func.isRequired,
-      userWentBack: React.PropTypes.func.isRequired,
-      singlePersonHousehold: React.PropTypes.func.isRequired,
-      userSubmittedData: React.PropTypes.func.isRequired
+      userWentBack: React.PropTypes.bool.isRequired,
+      singlePersonHousehold: React.PropTypes.bool.isRequired,
+      userSubmittedData: React.PropTypes.object.isRequired
     },
 
     getInitialState: function () {

--- a/public/javascripts/components/housing_question.js
+++ b/public/javascripts/components/housing_question.js
@@ -68,11 +68,19 @@
         dom.label({}, 'Shelter'),
         dom.br({}),
         this.renderAdditionalOptions(),
-        dom.input({ type: 'radio', name: 'livingQuestion', onClick: this.toggleAdditionalOptions }),
-        dom.label({}, 'None of the above'),
+        this.renderShowMoreOptionsButton(),
         dom.br({}),
         dom.br({})
       );
+    },
+
+    renderShowMoreOptionsButton: function () {
+      if (this.state.showMoreOptions === true) return null;
+
+      return dom.a({
+        onClick: this.toggleAdditionalOptions,
+        style: window.shared.LinkStyle
+      }, 'Show More Options');
     },
 
     toggleAdditionalOptions: function () {

--- a/public/javascripts/components/housing_question.js
+++ b/public/javascripts/components/housing_question.js
@@ -74,8 +74,20 @@
       );
     },
 
+    userSelectedAdditionalOption: function () {
+      return this.props.userWentBack && (
+        (this.props.userSubmittedData.car === 'true') ||
+        (this.props.userSubmittedData.motel === 'true') ||
+        (this.props.userSubmittedData.in_kind === 'true')
+      );
+    },
+
+    shouldShowMoreOptions: function () {
+      return (this.state.showMoreOptions || this.userSelectedAdditionalOption());
+    },
+
     renderShowMoreOptionsButton: function () {
-      if (this.state.showMoreOptions === true) return null;
+      if (this.shouldShowMoreOptions() === true) return null;
 
       return dom.span({
         style: {
@@ -93,7 +105,7 @@
     },
 
     renderAdditionalOptions: function () {
-      if (this.state.showMoreOptions === false) return null;
+      if (this.shouldShowMoreOptions() === false) return null;
 
       return dom.div({},
         dom.input({

--- a/public/javascripts/components/housing_question.js
+++ b/public/javascripts/components/housing_question.js
@@ -77,10 +77,15 @@
     renderShowMoreOptionsButton: function () {
       if (this.state.showMoreOptions === true) return null;
 
-      return dom.a({
-        onClick: this.toggleAdditionalOptions,
-        style: window.shared.LinkStyle
-      }, 'Show More Options');
+      return dom.span({
+        style: {
+          marginLeft: '16px'
+        },
+      }, dom.a({
+          onClick: this.toggleAdditionalOptions,
+          style: window.shared.LinkStyle
+        }, 'Show More Options')
+      );
     },
 
     toggleAdditionalOptions: function () {


### PR DESCRIPTION
# GIF

![handle-extra-housing-options-more-smart](https://cloud.githubusercontent.com/assets/3209501/17952144/cbbac388-6a35-11e6-805a-36c6d9a5b6c8.gif)

# Explanation 

If a user selects "Show More Options" on the housing question and then selects one of the additional options, if he or she presses the BACK button later in the process the menu will automatically be opened.