### PR TITLE
Updates to pay stubs

### DIFF
--- a/api/load_documents_data.rb
+++ b/api/load_documents_data.rb
@@ -10,7 +10,7 @@ json_string = File.open("public/documents_data.json").read
 raise "Wrong number of docs!" unless @data.size == 26
 
 PAY_STUBS = @data[0]
-raise "Wrong variable!" unless PAY_STUBS[:official_name] == "Pay Stubs"
+raise "Wrong variable!" unless PAY_STUBS[:official_name] == "Pay Stubs for the Past 30 Days"
 
 SOCIAL_SECURITY_CARD = @data[1]
 raise "Wrong variable!" unless SOCIAL_SECURITY_CARD[:official_name] == "Social Security Card"

--- a/public/documents_data.json
+++ b/public/documents_data.json
@@ -1,7 +1,7 @@
 [
   {
-    "official_name": "Pay Stubs",
-    "accessible_name": "Pay Stubs",
+    "official_name": "Pay Stubs for the Past 30 Days",
+    "accessible_name": "Pay Stubs for the Past 30 Days",
     "description": "A document describing your income before taxes are taken out",
     "instructions": {
       "text": "If you don't get paystubs from your employer, the SNAP office will automatically send your employer a letter.",

--- a/public/javascripts/components/document_results_display.js
+++ b/public/javascripts/components/document_results_display.js
@@ -158,7 +158,7 @@
         var doc = docs[0];
         var doc_name = doc.official_name;
         if (doc_name === 'Pay Stubs for the Past 30 Days' && !this.props.singlePersonHousehold) {
-          doc_name += ' for all employed members of your family';
+          doc_name += ' (for all employed members of your family)';
         };
 
         return dom.div({},

--- a/public/javascripts/components/document_results_display.js
+++ b/public/javascripts/components/document_results_display.js
@@ -154,14 +154,20 @@
 
       if (docs.length === 0) return null;
 
-      if (docs.length === 1) return dom.div({},
-        dom.span({}, 'You will also need your '),
-        dom.span(
-          { style: { fontWeight: 'bold' } },
-        docs[0].official_name + '.'),
-        dom.br({}),
-        dom.br({})
-      );
+      if (docs.length === 1) {
+        var doc = docs[0];
+        var doc_name = doc.official_name;
+        if (doc_name === 'Pay Stubs for the Past 30 Days' && !this.props.singlePersonHousehold) {
+          doc_name += ' for all employed members of your family';
+        };
+
+        return dom.div({},
+          dom.span({}, 'You will also need your '),
+          dom.span({ style: { fontWeight: 'bold' } }, doc_name + '.'),
+          dom.br({}),
+          dom.br({})
+        );
+      };
 
       if (this.props.singlePersonHousehold) {
         return dom.div({},

--- a/spec/documents_api_spec.rb
+++ b/spec/documents_api_spec.rb
@@ -53,7 +53,7 @@ describe Api::DocumentsRequest do
 
     it "returns correct income documents" do
       expect(subject.fetch_documents[:income_documents].size).to eq 1
-      expect(subject.fetch_documents[:income_documents][0][:official_name]).to eq 'Pay Stubs'
+      expect(subject.fetch_documents[:income_documents][0][:official_name]).to eq 'Pay Stubs for the Past 30 Days'
     end
 
   end


### PR DESCRIPTION
# Notes

+ Add 30 days reminder.
+ Add reminder that Pay Stubs apply to all employed family members when beneficiary is applying for a multi-member household.

# GIF

![updates-to-pay-stubs](https://cloud.githubusercontent.com/assets/3209501/18014282/35bfc4bc-6b90-11e6-85ba-20cee484b41e.gif)
