### PR TITLE
Use Montserrat for web screener font

### DIFF
--- a/public/javascripts/styles/button_style.js
+++ b/public/javascripts/styles/button_style.js
@@ -6,7 +6,7 @@
     color: 'white',
     border: '0px',
     borderRadius: '24px',
-    fontFamily: 'Open Sans',
+    fontFamily: 'Montserrat',
     fontSize: '18px',
     padding: '10px 20px',
     marginRight: '12px'

--- a/views/show.erb
+++ b/views/show.erb
@@ -1,4 +1,4 @@
-<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700'
+<link href='https://fonts.googleapis.com/css?family=Montserrat:400,700'
       rel='stylesheet'
       type='text/css'>
 


### PR DESCRIPTION
# Note 

+ Same font as public_template; greater style consistency across projects

# Screenshot 

![screen shot 2016-08-30 at 7 36 24 pm](https://cloud.githubusercontent.com/assets/3209501/18110892/26569cf6-6ee9-11e6-9367-42b6edc876c0.png)
