### PR TITLE
Change prompts to say 'Y or N' instead of 'Yes or No'

### DIFF
--- a/sms/sms_screener_questions.rb
+++ b/sms/sms_screener_questions.rb
@@ -15,7 +15,7 @@ SMS_SCREENER = {
   ),
   2 => (
     'Is everyone in your household a US citizen? ' +
-    'Yes or No.'
+    'Y or N.'
   ),
   3 => (
     'Select all that describe you: ' +
@@ -33,6 +33,6 @@ SMS_SCREENER = {
     'D. None of the above.'
   ),
   5 => (
-    'Do you have a State ID? Yes or No.'
+    'Do you have a State ID? Y or N.'
   )
 }


### PR DESCRIPTION
# Notes 

+ Either will be accepted by the screener
+ In mRelief's other projects, @genevievenielsen has seen that many users type Y or N regardless of if they are prompted with 'Y or N' or 'Yes or No'
+ Better to prompt the more convenient option
+ Fix #194