### PR TITLE
Dry up code for "Start Over" button

### DIFF
--- a/public/javascripts/components/screener.js
+++ b/public/javascripts/components/screener.js
@@ -166,16 +166,7 @@
     },
 
     onClickStartOver: function () {
-      this.setState({
-        answeredFirstPage: false,
-        answeredSecondPage: false,
-        hasResponseFromServer: false,
-        documentsDataFromServer: null,
-        userSubmittedData: DefaultData,
-        singlePersonHousehold: true,
-        errorFromServer: false,
-        hitBackButton: false
-      });
+      this.setState(this.getInitialState());
     },
 
     renderResultsFromServer: function () {


### PR DESCRIPTION
# Notes

+ Call `this.getInitialState()` so that we use the same code
+ This means the Start Over button is less likely to get out of sync